### PR TITLE
ES7.x returns dict for doc count

### DIFF
--- a/clio_utils.py
+++ b/clio_utils.py
@@ -72,6 +72,8 @@ def extract_docs(r, scroll=None, include_score=False):
     total = data['hits']['total']
     if _scroll_id is not None and scroll is not None:
         total = _scroll_id
+    elif type(total) is dict:  # Breaking change from ES 6.x --> 7.x
+        total = total['value']
     return total, docs
 
 


### PR DESCRIPTION
Closes #1

ES7.x returns dict for doc count. 

Fix: rather than querying what version the endpoint corresponds to I have opted simply to test the type. User tests don't show up any issues, and appears to be compatible across ES6.x and ES7.x now.