### PR TITLE
Update clio_lite_searchkit_lambda.py

### DIFF
--- a/clio_lite_searchkit_lambda.py
+++ b/clio_lite_searchkit_lambda.py
@@ -67,6 +67,11 @@ def lambda_handler(event, context=None):
                     continue
                 pop_upper_lim(row['range'])
 
+    # Fixes new host-authentication permissions, as this value
+    # won't match the lambda host
+    if 'Host' in event['headers']:
+        event['headers'].pop('Host')
+        
     # Generate the endpoint URL, and validate
     endpoint = event['headers'].pop('es-endpoint')
     if endpoint not in os.environ['ALLOWED_ENDPOINTS'].split(";"):

--- a/tests/test_clio_lite.py
+++ b/tests/test_clio_lite.py
@@ -111,7 +111,7 @@ def test_clio_keywords(mocked_search, expected_kw_output, raw_keyword_scores):
 
 @mock.patch('clio_lite.json')
 @mock.patch('clio_lite.requests')
-@mock.patch('clio_lite.extract_docs')
+@mock.patch('clio_lite.extract_docs', return_value=(None, None))
 def test_c_simple_query_no_filters(mocked_extract, mocked_reqs,
                                    mocked_json):
     # Make an input query fixture and output query fixture
@@ -127,7 +127,7 @@ def test_c_simple_query_no_filters(mocked_extract, mocked_reqs,
 
 @mock.patch('clio_lite.json.dumps', side_effect=lambda x: x)
 @mock.patch('clio_lite.requests')
-@mock.patch('clio_lite.extract_docs')
+@mock.patch('clio_lite.extract_docs', return_value=(None, None))
 def test_c_simple_query_filters(mocked_extract, mocked_reqs,
                                 mocked_json):
     # Make an input query fixture and output query fixture
@@ -154,7 +154,7 @@ def test_assert_fraction():
 
 @mock.patch('clio_lite.json.dumps', side_effect=lambda x: x)
 @mock.patch('clio_lite.requests')
-@mock.patch('clio_lite.extract_docs')
+@mock.patch('clio_lite.extract_docs', return_value=(None, None))
 def test_c_more_like_this_filters(mocked_extract, mocked_reqs,
                                   mocked_json,
                                   mlt_kwargs, mlt_query):
@@ -175,7 +175,7 @@ def test_c_more_like_this_filters(mocked_extract, mocked_reqs,
 
 @mock.patch('clio_lite.json.dumps', side_effect=lambda x: x)
 @mock.patch('clio_lite.requests')
-@mock.patch('clio_lite.extract_docs')
+@mock.patch('clio_lite.extract_docs', return_value=(None, None))
 def test_c_more_like_this_no_filters(mocked_extract, mocked_reqs,
                                      mocked_json,
                                      mlt_kwargs, mlt_query):
@@ -193,7 +193,7 @@ def test_c_more_like_this_no_filters(mocked_extract, mocked_reqs,
 
 @mock.patch('clio_lite.json.dumps', side_effect=lambda x: x)
 @mock.patch('clio_lite.requests')
-@mock.patch('clio_lite.extract_docs')
+@mock.patch('clio_lite.extract_docs', return_value=(None, None))
 def test_c_more_like_this_bad_limit(mocked_extract, mocked_reqs,
                                     mocked_json,
                                     mlt_kwargs, mlt_query):
@@ -212,7 +212,7 @@ def test_c_more_like_this_bad_limit(mocked_extract, mocked_reqs,
 
 @mock.patch('clio_lite.json.dumps', side_effect=lambda x: x)
 @mock.patch('clio_lite.requests')
-@mock.patch('clio_lite.extract_docs')
+@mock.patch('clio_lite.extract_docs', return_value=(None, None))
 def test_c_more_like_this_zero_total(mocked_extract, mocked_reqs,
                                      mocked_json,
                                      mlt_kwargs, mlt_query):


### PR DESCRIPTION
Under some new requirements (which I can't see documented anywhere), apparently using both `Host` and `IP` for access via the access policy leads to a conflict which gives the response "User is not authorized to perform this action". Anyway, just use the `IP` access policy and ensuring the `Host` is omitted fixes the issue